### PR TITLE
use cypress-recurse to visually diff until passes

### DIFF
--- a/cypress/integration/smile-spec.js
+++ b/cypress/integration/smile-spec.js
@@ -28,6 +28,7 @@ describe('Lego face', () => {
       ({ match }) => match,
       {
         log: true,
+        timeout: 4000,
       },
     )
   })

--- a/cypress/integration/smile-spec.js
+++ b/cypress/integration/smile-spec.js
@@ -1,10 +1,11 @@
 /// <reference types="cypress" />
 import { downloadViaDataUrl } from './utils'
+import { recurse } from 'cypress-recurse'
 
 describe('Lego face', () => {
-  it('smiles broadly', () => {
+  it('smiles broadly with wait', () => {
     cy.visit('/smile')
-    cy.wait(1000)
+    cy.wait(4000)
 
     downloadViaDataUrl('smile').then((filename) => {
       cy.log(`saved ${filename}`)
@@ -12,5 +13,22 @@ describe('Lego face', () => {
         match: true,
       })
     })
+  })
+
+  it('smiles broadly', () => {
+    cy.visit('/smile')
+
+    recurse(
+      () => {
+        return downloadViaDataUrl('smile').then((filename) => {
+          cy.log(`saved ${filename}`)
+          return cy.task('compare', { filename })
+        })
+      },
+      ({ match }) => match,
+      {
+        log: true,
+      },
+    )
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -870,6 +870,12 @@
         }
       }
     },
+    "cypress-recurse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.0.1.tgz",
+      "integrity": "sha512-z2lIxx+1gQ2TgydgANhs8TNyzddWvuBnG7bT1C+CntodsniIT4PJuodiGT2IVk5mANBpHRbCCQI2uVowNKd8cA==",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "cypress": "6.5.0",
+    "cypress-recurse": "1.0.1",
     "odiff-bin": "2.1.0",
     "prettier": "2.2.1",
     "serve": "11.3.2",


### PR DESCRIPTION
Visual flake is a huge problem when doing a visual comparison. Often we need to put extra assertions, hardcoded time waits just to get the page to look how it used to look before taking the visual snapshot. But what if our visual diffing was _fast_? Then we could grab and compare the images multiple times, auto-retrying just like we retry a regular Cypress assertion.

The test below shows how to do it. The golden image has a full smile. The test grabs bunch of canvas images and diffs them until the smile finally matches.

https://user-images.githubusercontent.com/2212006/109559159-55f2c500-7aa8-11eb-95e6-b6a127569b27.mp4

terminal shows odiff

<img width="803" alt="Screen Shot 2021-03-01 at 4 08 44 PM" src="https://user-images.githubusercontent.com/2212006/109559252-6dca4900-7aa8-11eb-829d-116bc2d88bdb.png">


