### PR TITLE
Show the automation screenshot via CDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ An animated [Chart.js bar chart](https://www.chartjs.org/samples/latest/scriptab
 
 Watch [the video](https://youtu.be/aeBclf9A92A) for more details
 
+## Native screenshots
+
+This repository is showing how to use Chrome debugger protocol to capture the browser screenshot natively in Chrome browsers. See the [screenshot-spec.js](./cypress/integration/screenshot-spec.js) test file.
+
 [ci image]: https://github.com/bahmutov/monalego/workflows/main/badge.svg?branch=main
 [ci url]: https://github.com/bahmutov/monalego/actions
 [renovate-badge]: https://img.shields.io/badge/renovate-app-blue.svg

--- a/cypress/integration/screenshot-spec.js
+++ b/cypress/integration/screenshot-spec.js
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+describe('Automation screenshot', () => {
+  it('captures the canvas', () => {
+    cy.visit('/smile')
+      .wait(2000)
+      .then(() => {
+        cy.log('Page.captureScreenshot')
+        // https://chromedevtools.github.io/devtools-protocol/
+        // https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot
+        return Cypress.automation('remote:debugger:protocol', {
+          command: 'Page.captureScreenshot',
+          params: {
+            format: 'png',
+          },
+        })
+      })
+      .its('data')
+      .then((base64) => {
+        console.log(base64)
+        cy.writeFile('test-smile.png', base64, 'base64')
+      })
+  })
+})


### PR DESCRIPTION
Use `Page.captureScreenshot` to get the entire window screenshot from Chrome and save as a PNG file